### PR TITLE
fix: sqlalchemy column type float returns double instead of float

### DIFF
--- a/pyathena/sqlalchemy_athena.py
+++ b/pyathena/sqlalchemy_athena.py
@@ -103,8 +103,6 @@ class AthenaStatementCompiler(SQLCompiler):
 
 
 class AthenaTypeCompiler(GenericTypeCompiler):
-    def visit_FLOAT(self, type_, **kw):
-        return self.visit_REAL(type_, **kw)
 
     def visit_REAL(self, type_, **kw):
         return "DOUBLE"


### PR DESCRIPTION
Right now `sqlalchemy.FLOAT` will create column as type `DOUBLE` in Athena rather than `FLOAT`