### PR TITLE
fix: adding back dbapi module for backward compatibility with sqlalchemy 1.4.x

### DIFF
--- a/pyathena/sqlalchemy/base.py
+++ b/pyathena/sqlalchemy/base.py
@@ -940,6 +940,10 @@ class AthenaDialect(DefaultDialect):
     def import_dbapi(cls) -> "ModuleType":
         return pyathena
 
+    @classmethod
+    def dbapi(cls) -> "ModuleType":  # type: ignore
+        return pyathena
+
     def _raw_connection(self, connection: Union[Engine, "Connection"]) -> "PoolProxiedConnection":
         if isinstance(connection, Engine):
             return connection.raw_connection()


### PR DESCRIPTION
Original: https://github.com/laughingman7743/PyAthena/pull/448